### PR TITLE
feat: Implement dual database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ Dies ist eine einfache Fullstack-Webanwendung.
 
 ---
 
+## ⚙️ Setup and Configuration
+
+This application requires a backend setup with connection to two PostgreSQL databases.
+
+### Environment Variables
+
+The backend requires the following environment variables to be set. You can use the `backend/.env.example` file as a template by creating a `.env` file in the `backend` directory.
+
+- `DATABASE_URL_1`: The connection string for the first PostgreSQL database.
+  - Example: `postgresql://user:password@host:port/database_name_1`
+- `DATABASE_URL_2`: The connection string for the second PostgreSQL database.
+  - Example: `postgresql://user:password@host:port/database_name_2`
+- `PORT`: (Optional) The port on which the backend server will run. Defaults to 3000.
+
+The `backend/.env.example` file has been updated to reflect these requirements.
+
+---
+
 ## 🧰 Technologien
 
 Dieses Projekt verwendet:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,2 @@
-DATABASE_URL=
+DATABASE_URL_1=your_first_database_connection_string_here
+DATABASE_URL_2=your_second_database_connection_string_here

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,11 +1,18 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+const pool1 = new Pool({
+  connectionString: process.env.DATABASE_URL_1,
   ssl: {
     rejectUnauthorized: false
   }
 });
 
-export default pool;
+const pool2 = new Pool({
+  connectionString: process.env.DATABASE_URL_2,
+  ssl: {
+    rejectUnauthorized: false
+  }
+});
+
+export { pool1, pool2 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,11 +1,6 @@
 const express = require("express");
 const cors = require("cors");
-const { Pool } = require("pg");
-
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
-});
+const { pool1, pool2 } = require("./db"); // Assuming db.js exports pool1 and pool2
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -14,31 +9,69 @@ app.use(cors());
 app.use(express.json()); // Middleware to parse JSON request bodies
 
 app.get("/api", async (req, res) => {
+  let db1Connected = false;
+  let db2Connected = false;
+  let db1Error = null;
+  let db2Error = null;
+  let time1 = null;
+  let time2 = null;
+
   try {
-    const result = await pool.query("SELECT NOW()");
-    res.json({ message: "Datenbank verbunden!", time: result.rows[0].now });
+    const result1 = await pool1.query("SELECT NOW()");
+    time1 = result1.rows[0].now;
+    db1Connected = true;
   } catch (err) {
-    console.error("DB-Fehler:", err.message);
-    res.status(500).json({ error: "Fehler bei Datenbankzugriff" });
+    console.error("DB1 connection error:", err.message);
+    db1Error = err.message;
+  }
+
+  try {
+    const result2 = await pool2.query("SELECT NOW()");
+    time2 = result2.rows[0].now;
+    db2Connected = true;
+  } catch (err) {
+    console.error("DB2 connection error:", err.message);
+    db2Error = err.message;
+  }
+
+  let message = "";
+  if (db1Connected && db2Connected) {
+    message = "Database 1 and Database 2 connected!";
+    res.json({ message, time1, time2 });
+  } else if (db1Connected) {
+    message = "Database 1 connected, Database 2 connection failed.";
+    res.status(500).json({ message, time1, db2Error });
+  } else if (db2Connected) {
+    message = "Database 2 connected, Database 1 connection failed.";
+    res.status(500).json({ message, time2, db1Error });
+  } else {
+    message = "Failed to connect to both Database 1 and Database 2.";
+    res.status(500).json({ message, db1Error, db2Error });
   }
 });
 
 // Create a new entry
 app.post("/api/entries", async (req, res) => {
-  const { content } = req.body;
+  const { content, dbIdentifier } = req.body;
 
   if (!content || content.trim() === "") {
     return res.status(400).json({ error: "Content cannot be empty" });
   }
 
+  if (dbIdentifier !== 'db1' && dbIdentifier !== 'db2') {
+    return res.status(400).json({ error: "Invalid dbIdentifier. Must be 'db1' or 'db2'." });
+  }
+
+  const selectedPool = dbIdentifier === 'db1' ? pool1 : pool2;
+
   try {
-    const result = await pool.query(
+    const result = await selectedPool.query(
       "INSERT INTO entries (content) VALUES ($1) RETURNING *",
       [content]
     );
     res.status(201).json(result.rows[0]);
   } catch (err) {
-    console.error("Error inserting entry:", err.message);
+    console.error(`Error inserting entry into ${dbIdentifier}:`, err.message);
     res.status(500).json({ error: "Failed to create entry" });
   }
 });
@@ -46,17 +79,24 @@ app.post("/api/entries", async (req, res) => {
 // Get all entries
 app.get("/api/entries", async (req, res) => {
   try {
-    const result = await pool.query("SELECT * FROM entries ORDER BY id");
-    res.status(200).json(result.rows);
+    const result1 = await pool1.query("SELECT * FROM entries ORDER BY id");
+    const entries1 = result1.rows.map(entry => ({ ...entry, source_db: 'db1' }));
+
+    const result2 = await pool2.query("SELECT * FROM entries ORDER BY id");
+    const entries2 = result2.rows.map(entry => ({ ...entry, source_db: 'db2' }));
+
+    const combinedEntries = [...entries1, ...entries2];
+    res.status(200).json(combinedEntries);
   } catch (err) {
     console.error("Error fetching entries:", err.message);
     res.status(500).json({ error: "Failed to fetch entries" });
   }
 });
 
-async function createEntriesTable() {
+async function createEntriesTable(pool, dbName) {
   const client = await pool.connect();
   try {
+    console.log(`Checking/creating "entries" table for ${dbName}...`);
     const result = await client.query(`
       CREATE TABLE IF NOT EXISTS entries (
         id SERIAL PRIMARY KEY,
@@ -64,19 +104,20 @@ async function createEntriesTable() {
       );
     `);
     if (result.command === 'CREATE') {
-      console.log('Table "entries" created successfully.');
+      console.log(`Table "entries" created successfully in ${dbName}.`);
     } else {
-      console.log('Table "entries" already exists.');
+      console.log(`Table "entries" already exists in ${dbName}.`);
     }
   } catch (err) {
-    console.error('Error creating table "entries":', err.message);
+    console.error(`Error creating table "entries" in ${dbName}:`, err.message);
   } finally {
     client.release();
   }
 }
 
 async function startServer() {
-  await createEntriesTable();
+  await createEntriesTable(pool1, 'Database 1');
+  await createEntriesTable(pool2, 'Database 2');
   app.listen(PORT, () => {
     console.log(`Server läuft auf Port ${PORT}`);
   });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ function App() {
   const [submissionError, setSubmissionError] = useState(null);
   const [entries, setEntries] = useState([]);
   const [fetchEntriesError, setFetchEntriesError] = useState(null);
+  const [selectedDb, setSelectedDb] = useState('db1'); // 'db1' or 'db2'
 
   const fetchEntries = useCallback(async () => {
     setFetchEntriesError(null);
@@ -72,7 +73,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ content: newEntryContent }),
+        body: JSON.stringify({ content: newEntryContent, dbIdentifier: selectedDb }),
       });
 
       if (response.status === 201) {
@@ -102,6 +103,26 @@ function App() {
       <h2>Create New Entry</h2>
       <form onSubmit={handleCreateEntry}>
         <div>
+          <label>
+            <input
+              type="radio"
+              value="db1"
+              checked={selectedDb === 'db1'}
+              onChange={(e) => setSelectedDb(e.target.value)}
+            />
+            Database 1
+          </label>
+          <label style={{ marginLeft: '10px' }}>
+            <input
+              type="radio"
+              value="db2"
+              checked={selectedDb === 'db2'}
+              onChange={(e) => setSelectedDb(e.target.value)}
+            />
+            Database 2
+          </label>
+        </div>
+        <div>
           <input
             type="text"
             value={newEntryContent}
@@ -120,8 +141,8 @@ function App() {
       ) : (
         <ul>
           {entries.map(entry => (
-            <li key={entry.id}>
-              ID: {entry.id} - Content: {entry.content}
+            <li key={`${entry.source_db}-${entry.id}`}>
+              ID: {entry.id} - Source: {entry.source_db === 'db1' ? 'Database 1' : 'Database 2'} - Content: {entry.content}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
This commit introduces functionality to allow the application to interact with two separate PostgreSQL databases.

Backend changes:
- Modified `backend/db.js` to manage two connection pools, configured via `DATABASE_URL_1` and `DATABASE_URL_2` environment variables.
- Updated `backend/index.js`:
    - API endpoint `POST /api/entries` now accepts a `dbIdentifier` ('db1' or 'db2') in the request body to specify the target database for new entries.
    - API endpoint `GET /api/entries` now fetches entries from both databases and returns a combined list. Each entry in the response includes a `source_db` field ('db1' or 'db2') to indicate its origin.
    - The `createEntriesTable` function is now parameterized and ensures the 'entries' table exists in both databases upon startup.
    - The `/api` health check now verifies connectivity to both databases.
- Added `DATABASE_URL_1` and `DATABASE_URL_2` to `backend/.env.example`.

Frontend changes:
- Modified `frontend/src/App.jsx`:
    - Added radio buttons to the entry form, allowing you to select either 'Database 1' or 'Database 2' for new submissions.
    - The selected database identifier is sent to the backend when creating an entry.
    - Entry display is updated to show the source database for each listed entry (e.g., "Source: Database 1").
    - List item keys are updated to `entry.source_db + '-' + entry.id` to ensure uniqueness.

Documentation:
- Updated `README.md` to reflect the new environment variable requirements (`DATABASE_URL_1`, `DATABASE_URL_2`).